### PR TITLE
Fix typo in settings.cpp

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -1,4 +1,4 @@
-#include "Settings.h"
+#include "settings.h"
 #include "core/system_manager.h"
 #include <iostream>  // For debugging purposes
 


### PR DESCRIPTION
You accidentally used "Settings.h" rather than "settings.h", small typo but that does break the build!