### PR TITLE
Update custom_build.yml

### DIFF
--- a/.github/workflows/custom_build.yml
+++ b/.github/workflows/custom_build.yml
@@ -209,7 +209,7 @@ jobs:
           cd ..
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ghost_esp_${{ github.event.inputs.board_type }}_${{ github.event.inputs.display_type }}
           path: ghost_esp_${{ github.event.inputs.board_type }}_${{ github.event.inputs.display_type }}.zip


### PR DESCRIPTION
Changed 'actions/upload-artifact@v3' to 'actions/download-artifact@v4' as v3 was deprecated November 30, 2024